### PR TITLE
Add MQTT sensor simulator tool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
           python-version: '3.12'
       - name: Install dev requirements
         run: pip install -r requirements-dev.txt
+      - name: Install sensor simulator requirements
+        run: pip install -r tools/sensor_sim/requirements.txt
       - name: Black format check
         run: black --check .
       - name: Ruff lint

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Install development dependencies and execute `pytest`:
 pip install -r requirements-dev.txt
 pytest
 ```
+
+## Uso del simulador de sensores
+
+Para generar datos de prueba puedes ejecutar el simulador:
+
+```bash
+python tools/sensor_sim/sensor_sim.py --config tools/sensor_sim/config.yaml --mqtt-host localhost --rate 1
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,14 @@ services:
       - mosquitto_data:/mosquitto/data
       - mosquitto_log:/mosquitto/log
 
+  # sensor-sim:
+  #   build: ./tools/sensor_sim
+  #   environment:
+  #     MQTT_HOST: mqtt
+  #     MQTT_PORT: 1883
+  #   depends_on:
+  #     - mosquitto
+
   keycloak:
     image: keycloak:24
     command: start-dev

--- a/docs/architecture/sensor_sim.md
+++ b/docs/architecture/sensor_sim.md
@@ -1,0 +1,5 @@
+```mermaid
+flowchart LR
+  Sim[Sensor Simulator] -->|MQTT| Broker((Mosquitto))
+  Broker --> ContextAdapter
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,5 @@ pytest-asyncio
 httpx
 asyncio-mqtt
 asgi_lifespan
+click
+paho-mqtt<2

--- a/tests/sensor_sim/test_publish.py
+++ b/tests/sensor_sim/test_publish.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from asyncio_mqtt import Client
+from jsonschema import validate
+import yaml
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "domain" / "ngsi-ld.yaml"
+with SCHEMA_PATH.open() as f:
+    SCHEMA = yaml.safe_load(f)
+
+
+def load_schema(entity_type: str) -> dict:
+    return {"$ref": f"#/$defs/{entity_type}", **SCHEMA}
+
+
+@pytest.fixture(scope="module")
+def mqtt_broker():
+    proc = subprocess.Popen(["mosquitto", "-p", "1884"])
+    time.sleep(1)
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.mark.asyncio
+async def test_publish(tmp_path, mqtt_broker):
+    os.environ["MQTT_HOST"] = "localhost"
+    os.environ["MQTT_PORT"] = "1884"
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text((Path("tools/sensor_sim/config.yaml").read_text()))
+
+    proc = subprocess.Popen(
+        [
+            "python",
+            "tools/sensor_sim/sensor_sim.py",
+            "--config",
+            str(cfg),
+            "--rate",
+            "0.5",
+            "--duration",
+            "2",
+            "--mqtt-host",
+            "localhost",
+            "--mqtt-port",
+            "1884",
+        ]
+    )
+    await asyncio.sleep(0.1)
+    async with Client("localhost", 1884) as sub:
+        async with sub.filtered_messages("smartport/#") as messages:
+            await sub.subscribe("smartport/#")
+            msg = await asyncio.wait_for(messages.__anext__(), timeout=5)
+    proc.wait()
+    data = json.loads(msg.payload.decode())
+    t = msg.topic.split("/")[1]
+    validate(data, load_schema(t))

--- a/tools/sensor_sim/Dockerfile
+++ b/tools/sensor_sim/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "sensor_sim.py"]

--- a/tools/sensor_sim/README.md
+++ b/tools/sensor_sim/README.md
@@ -1,0 +1,8 @@
+# Sensor Simulator
+
+Publica datos sintéticos de sensores por MQTT para probar SmartPort.
+
+```bash
+pip install -r requirements.txt
+python sensor_sim.py --config config.yaml --mqtt-host mqtt --rate 2
+```

--- a/tools/sensor_sim/config.yaml
+++ b/tools/sensor_sim/config.yaml
@@ -1,0 +1,16 @@
+rate: 1
+entities:
+  - entity_type: Sensor
+    id: sensor:1
+    sensor_type: temperature
+    unit: C
+    measuredProperty: temperature
+    location: [0, 0]
+  - entity_type: EnergyAsset
+    id: asset:1
+    kind: battery
+    capacity_kW: 100
+  - entity_type: BathyPoint
+    id: bathy:1
+    location: [0, 0]
+    depth_m: 20

--- a/tools/sensor_sim/requirements.txt
+++ b/tools/sensor_sim/requirements.txt
@@ -1,0 +1,4 @@
+asyncio-mqtt
+paho-mqtt<2
+click
+PyYAML

--- a/tools/sensor_sim/sensor_sim.py
+++ b/tools/sensor_sim/sensor_sim.py
@@ -1,0 +1,118 @@
+import asyncio
+import json
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+import yaml
+from asyncio_mqtt import Client
+from jsonschema import validate, ValidationError
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "domain" / "ngsi-ld.yaml"
+
+
+def load_schema(entity_type: str) -> dict:
+    with SCHEMA_PATH.open() as f:
+        schema = yaml.safe_load(f)
+    return {"$ref": f"#/$defs/{entity_type}", **schema}
+
+
+def load_config(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def make_sensor(cfg: dict) -> dict:
+    return {
+        "id": cfg["id"],
+        "type": cfg.get("sensor_type", "sensor"),
+        "location": {"type": "Point", "coordinates": cfg.get("location", [0, 0])},
+        "measuredProperty": cfg.get("measuredProperty", cfg.get("sensor_type", "temp")),
+        "unit": cfg.get("unit", "C"),
+        "lastValue": random.random() * 100,
+    }
+
+
+def make_energy(cfg: dict) -> dict:
+    return {
+        "id": cfg["id"],
+        "kind": cfg.get("kind", "battery"),
+        "capacity_kW": cfg.get("capacity_kW", 100),
+        "state_of_charge": random.random(),
+    }
+
+
+def make_bathy(cfg: dict) -> dict:
+    depth = cfg.get("depth_m", 10) + random.uniform(-1, 1)
+    return {
+        "id": cfg["id"],
+        "location": {"type": "Point", "coordinates": cfg.get("location", [0, 0])},
+        "depth_m": depth,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+CREATORS = {
+    "Sensor": make_sensor,
+    "EnergyAsset": make_energy,
+    "BathyPoint": make_bathy,
+}
+
+
+async def publish_loop(client: Client, cfg: dict, rate: float):
+    entity_type = cfg["entity_type"]
+    schema = load_schema(entity_type)
+    creator = CREATORS[entity_type]
+    while True:
+        entity = creator(cfg)
+        try:
+            validate(instance=entity, schema=schema)
+        except ValidationError as ex:
+            click.echo(f"Validation error for {entity['id']}: {ex}", err=True)
+        else:
+            topic = f"smartport/{entity_type}/{entity['id']}"
+            await client.publish(topic, json.dumps(entity))
+        await asyncio.sleep(rate)
+
+
+async def run(
+    config_path: str,
+    mqtt_host: str,
+    mqtt_port: int,
+    rate: float,
+    duration: float | None,
+):
+    config = load_config(Path(config_path))
+    rate = rate or config.get("rate", 1)
+    tasks = []
+    async with Client(mqtt_host, mqtt_port) as client:
+        for cfg in config.get("entities", []):
+            tasks.append(asyncio.create_task(publish_loop(client, cfg, rate)))
+        if duration:
+            await asyncio.sleep(duration)
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+        else:
+            await asyncio.gather(*tasks)
+
+
+@click.command()
+@click.option("--config", default="config.yaml", help="YAML config file")
+@click.option("--mqtt-host", default=lambda: os.getenv("MQTT_HOST", "mqtt"))
+@click.option(
+    "--mqtt-port",
+    default=lambda: int(os.getenv("MQTT_PORT", "1883")),
+    type=int,
+)
+@click.option("--rate", default=1.0, type=float, help="Publish interval in seconds")
+@click.option("--duration", default=None, type=float, help="Run for N seconds and exit")
+def main(config, mqtt_host, mqtt_port, rate, duration):
+    """Publish fake sensor data to MQTT."""
+    asyncio.run(run(config, mqtt_host, mqtt_port, rate, duration))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `sensor_sim` tool for generating fake NGSI-LD entities
- provide default config, Dockerfile and quick README
- add CI step to install tool requirements
- document simulator usage in README and architecture docs
- include (commented) sensor-sim service in docker-compose
- add tests that run the simulator and validate messages
- support click-based CLI to choose config, rate, duration and MQTT params

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686eb2b6f640832da32afeb400a88529