### PR TITLE
Implement twin-core microservice

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,6 +88,22 @@ services:
     volumes:
       - wiremock_data:/home/wiremock
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  twin-core:
+    build: ./services/twin_core
+    ports:
+      - "8030:8030"
+    environment:
+      WS_ENDPOINT: ws://context-adapter:8010
+      REDIS_HOST: redis
+    depends_on:
+      - redis
+      - context-adapter
+
 volumes:
   pgdata:
   mosquitto_data:

--- a/services/twin_core/Dockerfile
+++ b/services/twin_core/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install --production
+COPY src ./src
+RUN npm run build
+EXPOSE 8030
+CMD ["node", "dist/index.js"]

--- a/services/twin_core/README.md
+++ b/services/twin_core/README.md
@@ -1,0 +1,13 @@
+# twin-core
+
+GraphQL service for the 3D Digital Twin. It exposes an Apollo Server with a minimal schema and listens to entity updates via WebSocket.
+
+This service is a stub used for integration tests. The Cesium 3D loader is simplified and a local Redis instance caches entity states.
+
+## Development
+
+```bash
+npm install
+npm run build
+npm start
+```

--- a/services/twin_core/package.json
+++ b/services/twin_core/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "twin-core",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node dist/index.js",
+    "build": "tsc",
+    "dev": "nodemon --watch src --exec ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@apollo/server": "^4.8.2",
+    "graphql": "^16.6.0",
+    "ws": "^8.13.0",
+    "socket.io-client": "^4.7.4",
+    "redis": "^4.6.7",
+    "cesium": "^1.113"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.2",
+    "nodemon": "^3.0.1"
+  }
+}

--- a/services/twin_core/src/cesium/loader.ts
+++ b/services/twin_core/src/cesium/loader.ts
@@ -1,0 +1,5 @@
+// Placeholder loader utilities
+export async function loadScene() {
+  // In real service this would load glTF and bathymetry
+  return {};
+}

--- a/services/twin_core/src/index.ts
+++ b/services/twin_core/src/index.ts
@@ -1,0 +1,30 @@
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
+import { createClient } from 'redis';
+import { io } from 'socket.io-client';
+import { typeDefs, resolvers } from './schema.js';
+
+const WS_ENDPOINT = process.env.WS_ENDPOINT || 'ws://localhost:8010';
+const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
+
+async function main() {
+  const redis = createClient({ url: `redis://${REDIS_HOST}:6379` });
+  redis.on('error', (err) => console.error('Redis error', err));
+  await redis.connect();
+
+  const server = new ApolloServer({ typeDefs, resolvers: resolvers(redis) });
+  const { url } = await startStandaloneServer(server, { listen: { port: 8030 } });
+  console.log(`🚀 Twin-core ready at ${url}`);
+
+  const socket = io(WS_ENDPOINT);
+  socket.on('connect', () => console.log('WS connected'));
+  socket.on('entity_update', async (data: any) => {
+    const key = `entity:${data.id}`;
+    await redis.set(key, JSON.stringify(data));
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/twin_core/src/schema.ts
+++ b/services/twin_core/src/schema.ts
@@ -1,0 +1,43 @@
+import { gql } from 'graphql-tag';
+import { RedisClientType } from 'redis';
+
+export const typeDefs = gql`
+  type Query {
+    portAreas: [PortArea]
+    sensors(type: String): [Sensor]
+    energyAssets: [EnergyAsset]
+    bathyProfile(id: ID!): [BathyPoint]
+  }
+
+  type Subscription {
+    entityUpdated: EntityUpdate
+  }
+
+  type PortArea { id: ID! name: String geometry: String }
+  type Sensor   { id: ID! measuredProperty: String value: Float unit: String ts: String }
+  type EnergyAsset { id: ID! soc: Float power_kw: Float ts: String }
+  type BathyPoint  { id: ID! depth_m: Float lon: Float lat: Float ts: String }
+
+  union EntityUpdate = Sensor | EnergyAsset | BathyPoint
+`;
+
+export function resolvers(redis: RedisClientType) {
+  return {
+    Query: {
+      portAreas: async () => [],
+      sensors: async (_: unknown, args: { type?: string }) => [],
+      energyAssets: async () => [],
+      bathyProfile: async (_: unknown, args: { id: string }) => [],
+    },
+    Subscription: {
+      entityUpdated: {
+        subscribe: async function* () {
+          // placeholder async iterator
+          while (true) {
+            await new Promise((r) => setTimeout(r, 10000));
+          }
+        },
+      },
+    },
+  };
+}

--- a/services/twin_core/tsconfig.json
+++ b/services/twin_core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add new microservice `twin-core` with a minimal Apollo Server in TypeScript
- include cesium loader placeholder and GraphQL schema/resolvers
- dockerize `twin-core` and expose in docker-compose
- add Redis service for caching entity state

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q` *(fails: FileNotFoundError for `mosquitto` and `docker-compose`)*

------
https://chatgpt.com/codex/tasks/task_b_686ebf4de278832dbc3c76ba9c6520dc