### PR TITLE
feat: load testing & tuning

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,49 @@
+name: Performance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:24-dind
+        options: --privileged
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install locust==2.26 websocket-client
+      - name: Install k6
+        run: |
+          curl -L https://github.com/grafana/k6/releases/download/v0.50.0/k6-v0.50.0-linux-amd64.tar.gz -o k6.tgz
+          tar -xzf k6.tgz
+          sudo mv k6-v0.50.0-linux-amd64/k6 /usr/local/bin/k6
+      - name: Build stack
+        run: docker compose up -d --build
+      - name: Run Locust
+        run: |
+          locust -f tests/performance/locustfile.py --headless -u 80 -r 80 -t 2m --host http://localhost:8010 --csv locust
+      - name: Run k6 soak
+        run: k6 run tests/performance/k6_script.js --out csv=k6.csv
+      - name: Run pgbench
+        run: tests/performance/pgbench.sh
+      - name: Docker stats
+        run: docker stats --no-stream > docker_stats.txt
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: perf-report
+          path: |
+            k6.csv
+            locust_stats.csv
+            locust_stats_history.csv
+            docker_stats.txt
+      - name: Check SLA
+        run: python tests/performance/check_sla.py

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,22 @@
+# Pruebas de rendimiento
+
+Este documento describe los indicadores clave (KPIs) utilizados para evaluar el
+rendimiento de SmartPort.
+
+## KPIs
+
+- **rps**: peticiones por segundo procesadas.
+- **latency p50/p95**: latencias de la API en los percentiles 50 y 95.
+- **WS msg loss**: mensajes perdidos en las suscripciones WebSocket.
+- **TPS DB**: transacciones por segundo en la base de datos.
+
+## Resultados
+
+| Escenario              | rps antes | rps después | p95 antes | p95 después |
+|------------------------|---------:|-----------:|---------:|-----------:|
+| Locust API/WS          |          |            |          |            |
+| k6 Soak                |          |            |          |            |
+| pgbench                |          |            |          |            |
+
+La tabla anterior debe completarse tras ejecutar `tools/tune/tune.sh` y
+comparar los resultados antes y después del ajuste automático.

--- a/jobs/perf-pipeline/run_locust.yml
+++ b/jobs/perf-pipeline/run_locust.yml
@@ -1,0 +1,26 @@
+name: run_locust
+on:
+  workflow_call:
+    inputs:
+      host:
+        required: true
+        type: string
+jobs:
+  load:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Locust
+        run: pip install locust==2.26 websocket-client
+      - name: Run Locust
+        run: |
+          locust -f tests/performance/locustfile.py --headless \
+            -u 80 -r 80 -t 2m --host ${{ inputs.host }} \
+            --csv locust
+      - uses: actions/upload-artifact@v3
+        with:
+          name: locust-results
+          path: |
+            locust_stats.csv
+            locust_stats_history.csv
+            locust_failures.csv

--- a/services/context_adapter/Dockerfile
+++ b/services/context_adapter/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir gunicorn
 COPY . .
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8010"]
+CMD ["gunicorn", "app.main:app", "-k", "uvicorn.workers.UvicornWorker", "-w", "${WORKERS:-1}", "-b", "0.0.0.0:8010"]

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,34 @@
+# Pruebas de rendimiento
+
+Este directorio contiene los scripts utilizados para las pruebas de carga de SmartPort.
+
+## Locust
+
+`locustfile.py` define tres grupos de usuarios:
+- 30 usuarios publican en `/events/ingest` con cargas aleatorias de 1 a 3 KB.
+- 30 usuarios consultan `/entities/{t}/{id}` para obtener un acierto de caché.
+- 20 usuarios mantienen una suscripción WebSocket a `entity_update`.
+
+Ejemplo de ejecución:
+
+```bash
+locust -f tests/performance/locustfile.py --headless -u 80 -r 80 -t 2m --host http://localhost:8010
+```
+
+## k6
+
+`k6_script.js` ejecuta una prueba de tipo *soak* durante 30 minutos con 10
+usuarios virtuales enviando un mensaje cada 500 ms.
+
+```bash
+k6 run tests/performance/k6_script.js
+```
+
+## pgbench
+
+Para estresar la base de datos TimescaleDB se incluye `pgbench.sh` que lanza
+100 000 transacciones con 10 hilos.
+
+```bash
+./tests/performance/pgbench.sh
+```

--- a/tests/performance/check_sla.py
+++ b/tests/performance/check_sla.py
@@ -1,0 +1,16 @@
+import csv
+import sys
+
+history = "locust_stats_history.csv"
+rows = list(csv.DictReader(open(history)))
+last = rows[-1]
+try:
+    p95 = float(last.get("95%", 0))
+    total = float(last.get("Total Request Count", 0))
+    failures = float(last.get("Total Failure Count", 0))
+except ValueError:
+    sys.exit("invalid stats")
+fail_rate = failures / total if total else 0
+print(f"p95 latency: {p95} ms, fail rate: {fail_rate*100:.2f}%")
+if p95 > 250 or fail_rate > 0.01:
+    sys.exit("SLA breach")

--- a/tests/performance/k6_script.js
+++ b/tests/performance/k6_script.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '30m',
+  thresholds: {
+    http_req_failed: ['rate<0.001'],
+  },
+};
+
+export default function () {
+  const host = __ENV.CONTEXT_ADAPTER_HOST || 'http://localhost:8010';
+  const payload = JSON.stringify([{ id: 'soak', value: Math.random() }]);
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  const res = http.post(`${host}/events/ingest`, payload, params);
+  check(res, { 'accepted': (r) => r.status === 202 });
+}

--- a/tests/performance/locustfile.py
+++ b/tests/performance/locustfile.py
@@ -1,0 +1,55 @@
+import os
+import json
+import random
+from locust import FastHttpUser, task, between, events
+from websocket import create_connection
+
+
+class APIUser(FastHttpUser):
+    wait_time = between(1, 2)
+    host = os.getenv("CONTEXT_ADAPTER_HOST", "http://localhost:8010")
+
+    @task(3)
+    def ingest_event(self):
+        size = random.randint(1024, 3072)
+        payload = [
+            {"id": "device-%d" % random.randint(1, 100), "value": "x" * (size - 20)}
+        ]
+        self.client.post("/events/ingest", json=payload, name="POST /events/ingest")
+
+    @task(3)
+    def get_entity(self):
+        self.client.get("/entities/Sensor/1", name="GET /entities/{t}/{id}")
+
+
+class WSUser(FastHttpUser):
+    wait_time = between(1, 1)
+    ws_url = os.getenv("TWIN_CORE_WS", "ws://localhost:8030")
+
+    def on_start(self):
+        self.ws = create_connection(self.ws_url)
+        try:
+            self.ws.send(json.dumps({"action": "subscribe", "topic": "entity_update"}))
+        except Exception:
+            events.request_failure.fire(
+                request_type="ws",
+                name="connect",
+                response_time=0,
+                exception="subscribe_failed",
+            )
+
+    @task
+    def listen(self):
+        try:
+            self.ws.recv()
+            events.request_success.fire(
+                request_type="ws", name="recv", response_time=0, response_length=0
+            )
+        except Exception as exc:
+            events.request_failure.fire(
+                request_type="ws", name="recv", response_time=0, exception=exc
+            )
+
+    def on_stop(self):
+        if self.ws:
+            self.ws.close()

--- a/tests/performance/pgbench.sh
+++ b/tests/performance/pgbench.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker exec timeseries pgbench -c 10 -T 120 -f /workspace/Ports-360/tests/performance/pgbench.sql

--- a/tests/performance/pgbench.sql
+++ b/tests/performance/pgbench.sql
@@ -1,0 +1,2 @@
+INSERT INTO sensor_snapshot(id, measuredproperty, value, geom)
+VALUES (md5(random()::text), 'temp', random()*100, ST_SetSRID(ST_MakePoint(0,0),4326));

--- a/tools/tune/tune.sh
+++ b/tools/tune/tune.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+WORKERS=${WORKERS:-4}
+export WORKERS
+
+# Update postgres config
+docker compose exec -T postgres psql -U postgres -c "ALTER SYSTEM SET shared_buffers='512MB';"
+docker compose restart postgres
+
+docker compose up -d --build context-adapter
+
+echo "Running short benchmark..."
+locust -f tests/performance/locustfile.py --headless -u 10 -r 10 -t 1m --host http://localhost:8010 --csv tune


### PR DESCRIPTION
## Summary
- add Locust, k6 and pgbench performance tests
- document KPIs and tuning procedure
- add GitHub Actions workflow for nightly load tests
- support gunicorn workers via WORKERS env var
- provide tune.sh helper script

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q` *(fails: FileNotFoundError: 'docker-compose')*


------
https://chatgpt.com/codex/tasks/task_b_686edca9a664832da0830e50f04e82b3