### PR TITLE
Fix CI pipeline for Snyk and promtool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Run tests
         run: pytest -q
       - name: Snyk CLI setup
-        uses: snyk/actions/setup@v2
+        uses: snyk/actions/setup@v3
 
       - name: Snyk scan (fail on HIGH)
-        uses: snyk/actions/scan@v2
+        uses: snyk/actions/scan@v3
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -70,6 +70,7 @@ jobs:
           PROM_VER=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep '"tag_name":' | cut -d" -f4)
           curl -sL https://github.com/prometheus/prometheus/releases/download/${PROM_VER}/prometheus-${PROM_VER:1}.linux-amd64.tar.gz | tar xz
           sudo mv prometheus-*/promtool /usr/local/bin/promtool
+          echo "/usr/local/bin" >> $GITHUB_PATH
           promtool --version
       - name: Prometheus lint
         run: promtool check config infra/prometheus/prometheus.yml


### PR DESCRIPTION
## Summary
- update Snyk action calls to `v3`
- ensure promtool path is available in the CI lint job

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_686ee55c8354832dbc6c49b2ed279bf4