### PR TITLE
Fix Snyk action version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,10 @@ jobs:
         run: pytest -q
       # ---- Snyk security scan ----
       - name: Snyk CLI setup
-        uses: snyk/actions/setup@v1
+        uses: snyk/actions/setup@master
 
       - name: Snyk scan (fail on HIGH)
-        uses: snyk/actions/scan@v1
+        uses: snyk/actions/scan@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- point to `snyk/actions` master branch since the v1 tag doesn't exist

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: FileNotFoundError: 'mosquitto' and 'docker-compose')*


------
https://chatgpt.com/codex/tasks/task_b_6870350b7614832d953a0d0e7d0c41a2