### PR TITLE
Fix Snyk action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,16 +33,17 @@ jobs:
       - name: Run tests
         run: pytest -q
       # ---- Snyk security scan ----
-      - name: Snyk CLI setup
-        uses: snyk/actions/setup@master
-
       - name: Snyk scan (fail on HIGH)
-        uses: snyk/actions/scan@master
+        uses: snyk/actions/python@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          severity-threshold: high   # falla si HIGH o CRITICAL
-          sarif: true
+          args: --severity-threshold=high --sarif-file-output=snyk.sarif
+
+      - name: Upload Snyk results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
       # ----------------------------
       - name: Build and run compose
         run: |


### PR DESCRIPTION
## Summary
- use `snyk/actions/python@master` for security scanning
- upload SARIF results using `github/codeql-action/upload-sarif`

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'docker-compose')*

------
https://chatgpt.com/codex/tasks/task_b_68703c28b390832daa72fc1ebdefda58