### PR TITLE
Fix alembic path

### DIFF
--- a/services/timeseries/alembic.ini
+++ b/services/timeseries/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = alembic
+script_location = %(here)s/alembic
 
 [loggers]
 keys = root


### PR DESCRIPTION
## Summary
- ensure the alembic script location is relative to its ini file

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: FileNotFoundError: no such file or directory 'docker-compose')*
- `black --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_68703d99bb2c832db5e26105ccabb0f9