### PR TITLE
Fix migrations by using TimescaleDB image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         options: >-
           --privileged
       postgres:
-        image: postgres:16
+        image: timescale/timescaledb-ha:pg16
         env:
           POSTGRES_PASSWORD: smartport
           POSTGRES_DB: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - context-adapter
 
   postgres:
-    image: postgres:16
+    image: timescale/timescaledb-ha:pg16
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Summary
- use `timescale/timescaledb-ha:pg16` in CI
- use the same TimescaleDB image in docker-compose

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r tools/sensor_sim/requirements.txt`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'docker-compose')*

------
https://chatgpt.com/codex/tasks/task_b_68714874fa94832db508ccefc8bb1af3