### PR TITLE
Fix Alembic setup for PostGIS

### DIFF
--- a/services/timeseries/alembic/versions/0001_create_tables.py
+++ b/services/timeseries/alembic/versions/0001_create_tables.py
@@ -11,6 +11,7 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis")
     op.create_table(
         "sensor_snapshot",
         sa.Column("id", sa.Text, nullable=False),


### PR DESCRIPTION
## Summary
- ensure `postgis` extension is created by alembic migrations

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: FileNotFoundError - no such file or directory: 'docker-compose')*

------
https://chatgpt.com/codex/tasks/task_b_6871519037e4832d897dad3bbea7433a