### PR TITLE
Fix black formatting issues

### DIFF
--- a/tests/context_adapter/test_ingest.py
+++ b/tests/context_adapter/test_ingest.py
@@ -34,6 +34,7 @@ async def test_ingest(mqtt_broker):
 
     from services.context_adapter.app.main import app
     from libs.auth_middleware import auth_dependency
+
     app.dependency_overrides[auth_dependency] = lambda: {}
 
     sample = {


### PR DESCRIPTION
## Summary
- format tests/context_adapter/test_ingest.py with black

## Testing
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError for httpx, yaml, fastapi, asyncpg, asyncio_mqtt)*

------
https://chatgpt.com/codex/tasks/task_b_687161834148832d920d3808bc575612