### PR TITLE
Skip tests when missing external commands

### DIFF
--- a/tests/context_adapter/test_ingest.py
+++ b/tests/context_adapter/test_ingest.py
@@ -3,11 +3,15 @@ import json
 import os
 import subprocess
 import time
+import shutil
 
 import pytest
 import httpx
 from asgi_lifespan import LifespanManager
 from asyncio_mqtt import Client
+
+if shutil.which("mosquitto") is None:
+    pytest.skip("mosquitto not available", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/security/test_jwt.py
+++ b/tests/security/test_jwt.py
@@ -14,9 +14,16 @@ from libs.auth_middleware import get_password_token
 
 
 def _docker_available() -> bool:
+    """Return True if both docker and docker-compose are available."""
     try:
         subprocess.run(
             ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        subprocess.run(
+            ["docker-compose", "--version"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=True,

--- a/tests/sensor_sim/test_publish.py
+++ b/tests/sensor_sim/test_publish.py
@@ -4,11 +4,15 @@ import os
 import subprocess
 import time
 from pathlib import Path
+import shutil
 
 import pytest
 from asyncio_mqtt import Client
 from jsonschema import validate
 import yaml
+
+if shutil.which("mosquitto") is None:
+    pytest.skip("mosquitto not available", allow_module_level=True)
 
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "domain" / "ngsi-ld.yaml"
 with SCHEMA_PATH.open() as f:

--- a/tests/timeseries/test_insert.py
+++ b/tests/timeseries/test_insert.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess
 import time
+import shutil
 
 import pytest
 
@@ -12,9 +13,16 @@ from asyncio_mqtt import Client
 
 
 def _docker_available() -> bool:
+    """Return True if docker and docker-compose are available."""
     try:
         subprocess.run(
             ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        subprocess.run(
+            ["docker-compose", "--version"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=True,


### PR DESCRIPTION
## Summary
- skip MQTT-related tests when `mosquitto` binary is unavailable
- ensure docker-based tests also require `docker-compose`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871668ced10832db6fef2d3b9b3742a