### PR TITLE
Fix ruff unused-import error

### DIFF
--- a/tests/timeseries/test_insert.py
+++ b/tests/timeseries/test_insert.py
@@ -3,7 +3,6 @@ import json
 import os
 import subprocess
 import time
-import shutil
 
 import pytest
 


### PR DESCRIPTION
## Summary
- remove unused `shutil` import from timeseries tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68716aa64a24832da1bbd008b5eeb586