### PR TITLE
Fix Snyk workflow scanning path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,10 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --sarif-file-output=snyk.sarif
+          args: >-
+            --severity-threshold=high
+            --sarif-file-output=snyk.sarif
+            --file=requirements-dev.txt
 
       - name: Upload Snyk results
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Summary
- run Snyk against `requirements-dev.txt` to properly detect dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68716ea73434832dbf5695bb0c005f3d