### PR TITLE
Fix Snyk workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
             --severity-threshold=high
             --sarif-file-output=snyk.sarif
             --file=requirements-dev.txt
+            --package-manager=pip
 
       - name: Upload Snyk results
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Summary
- specify pip package manager for Snyk action

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_687170ee0d2c832d87aacd4bee94defb