### PR TITLE
Fix twin core build by updating Redis type

### DIFF
--- a/services/twin_core/src/schema.ts
+++ b/services/twin_core/src/schema.ts
@@ -21,7 +21,9 @@ export const typeDefs = gql`
   union EntityUpdate = Sensor | EnergyAsset | BathyPoint
 `;
 
-export function resolvers(redis: RedisClientType) {
+export function resolvers(
+  redis: RedisClientType<any, any, any>
+) {
   return {
     Query: {
       portAreas: async () => [],


### PR DESCRIPTION
## Summary
- update twin-core `resolvers` signature for compatibility with latest redis typings
- add generic parameters to allow `createClient()` typed instance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6873bfee3738832da240792222cf417b