### PR TITLE
Fix Keycloak image path

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
   #     - mosquitto
 
   keycloak:
-    image: keycloak:24
+    image: quay.io/keycloak/keycloak:24
     command: start-dev
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- fix docker image path for Keycloak

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873c46ac358832d859ed3f2025444ce