### PR TITLE
Fix twin-core npm dependency version

### DIFF
--- a/services/twin_core/package.json
+++ b/services/twin_core/package.json
@@ -16,8 +16,8 @@
     "jose": "^5.2.4",
     "cesium": "^1.113",
     "express": "^4.19.2",
-    "express-prom-bundle": "^7.2.1",
-    "prom-client": "^14.3.1"
+    "express-prom-bundle": "^6.6.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "typescript": "^5.4.0",


### PR DESCRIPTION
## Summary
- fix express-prom-bundle dependency to a valid version
- update prom-client to satisfy bundle requirements

## Testing
- `pytest -q`
- `npm install --production --legacy-peer-deps` in services/twin_core

------
https://chatgpt.com/codex/tasks/task_b_6873c83dcdb4832db6ff79e74fb969b1