### PR TITLE
Fix twin-core build

### DIFF
--- a/services/twin_core/Dockerfile
+++ b/services/twin_core/Dockerfile
@@ -1,8 +1,12 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json tsconfig.json ./
-RUN npm install --production
+# Install all dependencies including devDependencies for the build
+RUN npm install
 COPY src ./src
+# Compile TypeScript sources
 RUN npm run build
+# Remove development dependencies after build
+RUN npm prune --production
 EXPOSE 8030
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- ensure twin-core Dockerfile installs dev dependencies for TypeScript build

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873cb9ee4c0832d9bcdf63e44ac0379