### PR TITLE
Fix twin-core build

### DIFF
--- a/services/twin_core/package.json
+++ b/services/twin_core/package.json
@@ -14,6 +14,7 @@
     "socket.io-client": "^4.7.4",
     "redis": "^4.6.7",
     "jose": "^5.2.4",
+    "graphql-tag": "^2.12.6",
     "cesium": "^1.113",
     "express": "^4.19.2",
     "express-prom-bundle": "^6.6.0",

--- a/services/twin_core/src/auth.ts
+++ b/services/twin_core/src/auth.ts
@@ -1,5 +1,9 @@
 import { createRemoteJWKSet, jwtVerify } from 'jose';
-import { PluginDefinition } from '@apollo/server';
+import type {
+  ApolloServerPlugin,
+  BaseContext,
+  GraphQLRequestContextDidResolveOperation,
+} from '@apollo/server';
 
 const issuer = process.env.KEYCLOAK_URL?.replace(/\/$/, '') + '/realms/' + (process.env.KEYCLOAK_REALM || 'smartport');
 const JWKS = createRemoteJWKSet(new URL(`${issuer}/protocol/openid-connect/certs`));
@@ -8,12 +12,14 @@ export async function verify(token: string) {
   await jwtVerify(token, JWKS, { issuer });
 }
 
-export function authPlugin(): PluginDefinition {
+export function authPlugin(): ApolloServerPlugin<BaseContext> {
   return {
     async requestDidStart() {
       return {
-        async didResolveOperation({ request }) {
-          const auth = request.http?.headers.get('authorization');
+        async didResolveOperation(
+          requestContext: GraphQLRequestContextDidResolveOperation<BaseContext>,
+        ) {
+          const auth = requestContext.request.http?.headers.get('authorization');
           if (!auth || !auth.startsWith('Bearer ')) {
             throw new Error('Unauthorized');
           }


### PR DESCRIPTION
## Summary
- install `graphql-tag` for GraphQL template literals
- adapt `authPlugin` to use updated Apollo Server types

## Testing
- `npm run build` in `services/twin_core`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, yaml, asyncio_mqtt, fastapi, asyncpg)*

------
https://chatgpt.com/codex/tasks/task_b_6873ce87deb8832db867a7169e5ba94a