### PR TITLE
Add Let's Encrypt to Traefik

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -130,12 +130,13 @@ services:
     command:
       - --providers.file.filename=/etc/traefik/traefik.yml
     ports:
-      - "8443:443"
+      - "80:80"
+      - "443:443"
       - "8081:8081"
     volumes:
       - ./infra/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./infra/traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
-      - ./infra/traefik/certs:/certs:ro
+      - ./infra/traefik/certs:/certs
     depends_on:
       - context-adapter
       - twin-core

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -5,25 +5,29 @@ http:
       service: context-adapter
       entryPoints:
         - websecure
-      tls: {}
+      tls:
+        certResolver: letsencrypt
     gql:
       rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/gql`)"
       service: twin-core
       entryPoints:
         - websecure
-      tls: {}
+      tls:
+        certResolver: letsencrypt
     db:
       rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/db`)"
       service: timeseries
       entryPoints:
         - websecure
-      tls: {}
+      tls:
+        certResolver: letsencrypt
     dashboard:
       rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/`)"
       service: dashboard
       entryPoints:
         - websecure
-      tls: {}
+      tls:
+        certResolver: letsencrypt
   services:
     context-adapter:
       loadBalancer:
@@ -41,7 +45,3 @@ http:
       loadBalancer:
         servers:
           - url: http://dashboard:80
-tls:
-  certificates:
-    - certFile: /certs/local.crt
-      keyFile: /certs/local.key

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -11,3 +11,11 @@ providers:
     filename: /etc/traefik/dynamic.yml
 metrics:
   prometheus: {}
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@optimainterface.com
+      storage: /certs/acme.json
+      httpChallenge:
+        entryPoint: web


### PR DESCRIPTION
## Summary
- configure cert resolver for Let's Encrypt via HTTP challenge
- use that resolver on every router
- expose ports 80 and 443 for Traefik and mount cert storage rw

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873fd15dd7c832dad0d72cdf8866a1c