### PR TITLE
Fix Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ cp infra/.env.example infra/.env
 docker compose up --build
 ```
 
+`infra/.env` contains the credentials used by the containers. Copying the
+example file is required before starting the stack, otherwise many services will
+fail to boot.
+
 The sample FastAPI service is available at [http://localhost:8000/docs](http://localhost:8000/docs).
 
 Add `smartport.local` to `/etc/hosts` pointing to `127.0.0.1` to access the stack through Traefik using HTTPS.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,9 @@ services:
       - ./services/template_service:/app
 
   context-adapter:
-    build: ./services/context_adapter
+    build:
+      context: .
+      dockerfile: services/context_adapter/Dockerfile
     env_file:
       - ${PWD}/infra/.env
     ports:
@@ -58,7 +60,9 @@ services:
       - mosquitto_log:/mosquitto/log
 
   timeseries:
-    build: ./services/timeseries
+    build:
+      context: .
+      dockerfile: services/timeseries/Dockerfile
     env_file:
       - ${PWD}/infra/.env
     depends_on:

--- a/services/context_adapter/Dockerfile
+++ b/services/context_adapter/Dockerfile
@@ -1,7 +1,15 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt ./
+
+# Install Python dependencies
+COPY services/context_adapter/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir gunicorn
-COPY . .
-CMD ["gunicorn", "app.main:app", "-k", "uvicorn.workers.UvicornWorker", "-w", "${WORKERS:-1}", "-b", "0.0.0.0:8010"]
+
+# Copy service code and shared libraries
+COPY services/context_adapter/ .
+COPY libs ./libs
+
+# Launch the service with the configured number of workers. Using ``sh -c``
+# allows the ``WORKERS`` environment variable to be expanded correctly.
+CMD ["sh", "-c", "gunicorn app.main:app -k uvicorn.workers.UvicornWorker -w ${WORKERS:-1} -b 0.0.0.0:8010"]

--- a/services/timeseries/Dockerfile
+++ b/services/timeseries/Dockerfile
@@ -1,6 +1,12 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt ./
+
+# Install Python dependencies
+COPY services/timeseries/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+
+# Copy service code and shared libraries
+COPY services/timeseries/ .
+COPY libs ./libs
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8020"]

--- a/services/twin_core/package.json
+++ b/services/twin_core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "twin-core",
   "version": "0.1.0",
-  "type": "module",
   "scripts": {
     "start": "node dist/index.js",
     "build": "tsc",


### PR DESCRIPTION
## Summary
- include shared libs when building context-adapter and timeseries images
- expand WORKERS variable correctly by launching gunicorn via shell
- make twin-core run as CommonJS by removing the module type
- build backend images from repository root
- document the need for `infra/.env` file before starting the stack

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687402c83c38832d889844ee02333a3e