### PR TITLE
Change default Keycloak port to 8181

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Seguridad y autenticación
 
-Este documento describe el flujo OIDC empleado en SmartPort. Keycloak expone el realm `smartport` con los clientes definidos para cada servicio. Los microservicios verifican los JWT firmados mediante RS256 y emitidos por `http://keycloak:8080`.
+Este documento describe el flujo OIDC empleado en SmartPort. Keycloak expone el realm `smartport` con los clientes definidos para cada servicio. Los microservicios verifican los JWT firmados mediante RS256 y emitidos por `http://keycloak:8181`.
 
 ```mermaid
 graph TD

--- a/libs/auth_middleware.py
+++ b/libs/auth_middleware.py
@@ -6,7 +6,9 @@ import httpx
 from fastapi import Header, HTTPException
 from jose import jwt
 
-KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://keycloak:8080")
+# Default Keycloak URL used by local development and tests. The port was
+# changed from 8080 to 8181 to avoid conflicts with other services.
+KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://keycloak:8181")
 REALM = os.getenv("KEYCLOAK_REALM", "smartport")
 JWKS_URL = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/certs"
 ISSUER = f"{KEYCLOAK_URL}/realms/{REALM}"

--- a/tests/security/test_jwt.py
+++ b/tests/security/test_jwt.py
@@ -48,7 +48,7 @@ def keycloak_container():
 
 @pytest.mark.asyncio
 async def test_jwt_required(keycloak_container):
-    os.environ["KEYCLOAK_URL"] = "http://localhost:8080"
+    os.environ["KEYCLOAK_URL"] = "http://localhost:8181"
     os.environ["KEYCLOAK_REALM"] = "smartport"
     token = get_password_token("dashboard", "admin", "admin")
     from services.context_adapter.app.main import app


### PR DESCRIPTION
## Summary
- use port 8181 by default in the auth middleware
- update security docs to mention the new port
- adapt JWT tests to the changed port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876e6ac75d8832d9a886e8c895e6ee4