### PR TITLE
Update domain to ports360.online

### DIFF
--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -1,22 +1,22 @@
 http:
   routers:
     api:
-      rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/api`)"
+      rule: "Host(`ports360.online`) && PathPrefix(`/api`)"
       service: context-adapter
       entryPoints: [web]
 
     gql:
-      rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/gql`)"
+      rule: "Host(`ports360.online`) && PathPrefix(`/gql`)"
       service: twin-core
       entryPoints: [web]
 
     db:
-      rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/db`)"
+      rule: "Host(`ports360.online`) && PathPrefix(`/db`)"
       service: timeseries
       entryPoints: [web]
 
     dashboard:
-      rule: "Host(`ports360.optimainterface.com`) && PathPrefix(`/`)"
+      rule: "Host(`ports360.online`) && PathPrefix(`/`)"
       service: dashboard
       entryPoints: [web]
 


### PR DESCRIPTION
## Summary
- configure Traefik routers for the `ports360.online` domain

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6876e99622e0832da32cf83dfc53b8ef