### PR TITLE
Add ads.txt for dashboard

### DIFF
--- a/ui/dashboard/README.md
+++ b/ui/dashboard/README.md
@@ -8,3 +8,9 @@ npm run dev
 ```
 
 The app will be available at http://localhost:5173.
+
+### Static assets
+
+Additional files placed under `public/` are copied verbatim to the production
+build directory. This repository includes an `ads.txt` placeholder so requests
+to `/ads.txt` do not trigger `404` errors in the web server logs.

--- a/ui/dashboard/public/ads.txt
+++ b/ui/dashboard/public/ads.txt
@@ -1,0 +1,2 @@
+# Authorized digital sellers (placeholder)
+example.com, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- serve a basic `ads.txt` from the dashboard
- document `public/` folder usage for static assets

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6877694311f0832dbc9622069b070f38