### PR TITLE
Add WebSocket support

### DIFF
--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -15,6 +15,11 @@ http:
       service: timeseries
       entryPoints: [web]
 
+    ws:
+      rule: "Host(`ports360.online`) && PathPrefix(`/ws`)"
+      service: context-adapter
+      entryPoints: [web]
+
     dashboard:
       rule: "Host(`ports360.online`) && PathPrefix(`/`)"
       service: dashboard


### PR DESCRIPTION
## Summary
- add WebSocket endpoint in context adapter
- broadcast MQTT events to WebSocket clients
- route `/ws` path through Traefik

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68777ca96744832d8d42eb89a9660c9b