### PR TITLE
Add TLS WebSocket router

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Traefik exposes the internal services under distinct path prefixes:
 - `/api/*` forwards to the Context Adapter
 - `/db/*` forwards to the Timeseries Writer
 - `/gql/*` forwards to the Twin Core
+- `/ws` forwards to the Context Adapter WebSocket endpoint and is
+  available over `ws://` and `wss://`
 
 These prefixes are stripped, so the backends keep their original routes such as `/health` or `/metrics`.
 

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -23,6 +23,12 @@ http:
       service: context-adapter
       entryPoints: [web]
 
+    ws-secure:
+      rule: "Host(`ports360.online`) && PathPrefix(`/ws`)"
+      service: context-adapter
+      entryPoints: [websecure]
+      tls: {}
+
     dashboard:
       rule: "Host(`ports360.online`) && PathPrefix(`/`)"
       service: dashboard


### PR DESCRIPTION
## Summary
- expose `/ws` on Traefik's `websecure` entrypoint to support wss
- document WebSocket routing in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a2a612d24832d96d2f49f0eef6f9a