### PR TITLE
Fix domain mismatch for Traefik routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ fail to boot.
 
 The sample FastAPI service is available at [http://localhost:8000/docs](http://localhost:8000/docs).
 
-Add `smartport.local` to `/etc/hosts` pointing to `127.0.0.1` to access the stack through Traefik using HTTPS.
+Add `ports360.online` to `/etc/hosts` pointing to `127.0.0.1` to access the stack through Traefik using HTTPS.
 
 Traefik exposes the internal services under distinct path prefixes:
 


### PR DESCRIPTION
## Summary
- update README to list `ports360.online` as the host that Traefik expects

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687a32d22680832dbbd51f36ae07435f