### PR TITLE
Add curl example for GraphQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ npm run build
 npm start
 ```
 
+### Ejemplo de consulta GraphQL
+
+El servicio Twin Core protege su API frente a ataques CSRF, por lo que las
+peticiones deben incluir las cabeceras adecuadas. Si accedes al servicio a
+través de Traefik, la ruta es `http://localhost:8000/gql`; de manera directa, es
+`http://localhost:8030/`.
+
+Ejemplo con `curl`:
+
+```bash
+curl -X POST http://localhost:8000/gql \
+  -H 'Content-Type: application/json' \
+  -H 'x-apollo-operation-name: Test' \
+  -d '{"query":"{ __typename }"}'
+```
+
 ### Dashboard web
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to query the GraphQL API with curl and required CSRF headers

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a3b196054832d91d64b6eb47433c2