### PR TITLE
Fix failing tests by using correct service ports

### DIFF
--- a/tests/security/test_jwt.py
+++ b/tests/security/test_jwt.py
@@ -48,7 +48,7 @@ def keycloak_container():
 
 @pytest.mark.asyncio
 async def test_jwt_required(keycloak_container):
-    os.environ["KEYCLOAK_URL"] = "http://localhost:8181"
+    os.environ["KEYCLOAK_URL"] = "http://localhost:18080"
     os.environ["KEYCLOAK_REALM"] = "smartport"
     token = get_password_token("dashboard", "admin", "admin")
     from services.context_adapter.app.main import app

--- a/tests/timeseries/test_insert.py
+++ b/tests/timeseries/test_insert.py
@@ -45,7 +45,7 @@ def services():
 
 @pytest.mark.asyncio
 async def test_insert(services):
-    os.environ["PGHOST"] = "localhost"
+    os.environ["PGHOST"] = "localhost:15432"
     os.environ["PGUSER"] = "postgres"
     os.environ["PGPASSWORD"] = "smartport"
     os.environ["PGDATABASE"] = "postgres"
@@ -75,7 +75,11 @@ async def test_insert(services):
             await asyncio.sleep(2)
 
     conn = await asyncpg.connect(
-        host="localhost", user="postgres", password="smartport", database="postgres"
+        host="localhost",
+        port=15432,
+        user="postgres",
+        password="smartport",
+        database="postgres",
     )
     count = await conn.fetchval("SELECT count(*) FROM sensor_snapshot")
     await conn.close()


### PR DESCRIPTION
## Summary
- point Keycloak URL to correct port in JWT test
- use the exposed PostgreSQL port in timeseries insert test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a529e4a28832da64d003cd0e79a11