### PR TITLE
Enable sensor control from dashboard

### DIFF
--- a/ui/dashboard/README.md
+++ b/ui/dashboard/README.md
@@ -9,6 +9,9 @@ npm run dev
 
 The app will be available at http://localhost:5173.
 
+Set `VITE_API_BASE` to the backend URL (e.g. `http://localhost:8000`) to enable
+API calls from the dashboard.
+
 ### Static assets
 
 Additional files placed under `public/` are copied verbatim to the production

--- a/ui/dashboard/src/App.tsx
+++ b/ui/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 import MapView from './components/MapView'
 import SensorTable from './components/SensorTable'
+import SensorControls from './components/SensorControls'
 import EnergyGauge from './components/EnergyGauge'
 import { FakeDataProvider } from './utils/mock'
 
@@ -15,6 +16,9 @@ export default function App() {
         </div>
         <div className="bg-white p-4 rounded shadow">
           <SensorTable />
+        </div>
+        <div className="bg-white p-4 rounded shadow">
+          <SensorControls />
         </div>
       </div>
     </FakeDataProvider>

--- a/ui/dashboard/src/components/SensorControls.tsx
+++ b/ui/dashboard/src/components/SensorControls.tsx
@@ -1,0 +1,50 @@
+import { useStore } from '../utils/mock'
+import { patchEntity } from '../utils/api'
+
+export default function SensorControls() {
+  const sensors = useStore(s => s.sensorReadings)
+
+  const uniqueIds = Array.from(new Set(sensors.map(r => r.id)))
+
+  const updateValue = async (id: string) => {
+    const input = prompt('Nuevo valor para ' + id)
+    if (!input) return
+    const value = parseFloat(input)
+    if (isNaN(value)) return
+    try {
+      await patchEntity('Sensor', id, { lastValue: value })
+      const reading = {
+        id,
+        property: 'manual',
+        value,
+        unit: 'C',
+        timestamp: new Date().toISOString(),
+      }
+      useStore.setState(state => {
+        const readings = [reading, ...state.sensorReadings]
+        return { sensorReadings: readings.slice(0, 10) }
+      })
+    } catch (err) {
+      alert('Error al actualizar')
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="font-bold mb-2">Control de Sensores</h2>
+      <ul className="space-y-2">
+        {uniqueIds.map(id => (
+          <li key={id} className="flex items-center gap-2">
+            <span className="flex-1">{id}</span>
+            <button
+              className="px-2 py-1 bg-blue-500 text-white rounded"
+              onClick={() => updateValue(id)}
+            >
+              Actualizar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/ui/dashboard/src/components/__tests__/SensorControls.test.tsx
+++ b/ui/dashboard/src/components/__tests__/SensorControls.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import SensorControls from '../SensorControls'
+import { FakeDataProvider } from '../../utils/mock'
+
+describe('SensorControls', () => {
+  it('renders controls', () => {
+    const { getByText } = render(
+      <FakeDataProvider>
+        <SensorControls />
+      </FakeDataProvider>,
+    )
+    expect(getByText('Control de Sensores')).toBeTruthy()
+  })
+})

--- a/ui/dashboard/src/utils/api.ts
+++ b/ui/dashboard/src/utils/api.ts
@@ -1,0 +1,13 @@
+export async function patchEntity(type: string, id: string, patch: object): Promise<void> {
+  const base = import.meta.env.VITE_API_BASE || ''
+  const resp = await fetch(`${base}/api/entities/${type}/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(patch),
+  })
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`)
+  }
+}


### PR DESCRIPTION
## Summary
- add SensorControls component and API helper
- show SensorControls in the dashboard
- document VITE_API_BASE in dashboard README
- test SensorControls rendering

## Testing
- `pytest -q`
- `npx vitest run --reporter=verbose`

------
https://chatgpt.com/codex/tasks/task_b_687aab8ac428832db1fcaa11859fb999