### PR TITLE
Enable manual sensor control

### DIFF
--- a/ui/dashboard/src/App.tsx
+++ b/ui/dashboard/src/App.tsx
@@ -6,7 +6,7 @@ import { FakeDataProvider } from './utils/mock'
 
 export default function App() {
   return (
-    <FakeDataProvider>
+    <FakeDataProvider auto={false}>
       <div className="container mx-auto p-4 grid gap-4 grid-cols-1 md:grid-cols-2">
         <div className="h-96 md:row-span-2">
           <MapView />

--- a/ui/dashboard/src/components/SensorControls.tsx
+++ b/ui/dashboard/src/components/SensorControls.tsx
@@ -3,6 +3,9 @@ import { patchEntity } from '../utils/api'
 
 export default function SensorControls() {
   const sensors = useStore(s => s.sensorReadings)
+  const addSensor = useStore(s => s.addSensor)
+  const updateSensor = useStore(s => s.updateSensor)
+  const removeSensor = useStore(s => s.removeSensor)
 
   const uniqueIds = Array.from(new Set(sensors.map(r => r.id)))
 
@@ -13,25 +16,42 @@ export default function SensorControls() {
     if (isNaN(value)) return
     try {
       await patchEntity('Sensor', id, { lastValue: value })
-      const reading = {
-        id,
-        property: 'manual',
-        value,
-        unit: 'C',
-        timestamp: new Date().toISOString(),
-      }
-      useStore.setState(state => {
-        const readings = [reading, ...state.sensorReadings]
-        return { sensorReadings: readings.slice(0, 10) }
-      })
+      updateSensor(id, value)
     } catch (err) {
       alert('Error al actualizar')
     }
   }
 
+  const createSensor = async () => {
+    const id = prompt('ID del nuevo sensor')
+    if (!id) return
+    const valStr = prompt('Valor inicial')
+    if (!valStr) return
+    const value = parseFloat(valStr)
+    if (isNaN(value)) return
+    try {
+      await patchEntity('Sensor', id, { lastValue: value })
+      addSensor(id, value)
+    } catch (err) {
+      alert('Error al crear')
+    }
+  }
+
+  const deleteSensor = (id: string) => {
+    removeSensor(id)
+  }
+
   return (
     <div>
       <h2 className="font-bold mb-2">Control de Sensores</h2>
+      <div className="mb-2">
+        <button
+          className="px-2 py-1 bg-green-600 text-white rounded"
+          onClick={createSensor}
+        >
+          Crear Sensor
+        </button>
+      </div>
       <ul className="space-y-2">
         {uniqueIds.map(id => (
           <li key={id} className="flex items-center gap-2">
@@ -41,6 +61,12 @@ export default function SensorControls() {
               onClick={() => updateValue(id)}
             >
               Actualizar
+            </button>
+            <button
+              className="px-2 py-1 bg-red-500 text-white rounded"
+              onClick={() => deleteSensor(id)}
+            >
+              Eliminar
             </button>
           </li>
         ))}

--- a/ui/dashboard/src/components/__tests__/EnergyGauge.test.tsx
+++ b/ui/dashboard/src/components/__tests__/EnergyGauge.test.tsx
@@ -6,7 +6,7 @@ import { FakeDataProvider } from '../../utils/mock'
 describe('EnergyGauge', () => {
   it('renders gauge', () => {
     const { getByText } = render(
-      <FakeDataProvider>
+      <FakeDataProvider auto={false}>
         <EnergyGauge />
       </FakeDataProvider>,
     )

--- a/ui/dashboard/src/components/__tests__/MapView.test.tsx
+++ b/ui/dashboard/src/components/__tests__/MapView.test.tsx
@@ -6,7 +6,7 @@ import { FakeDataProvider } from '../../utils/mock'
 describe('MapView', () => {
   it('renders without crashing', () => {
     render(
-      <FakeDataProvider>
+      <FakeDataProvider auto={false}>
         <div style={{ height: 400 }}>
           <MapView />
         </div>

--- a/ui/dashboard/src/components/__tests__/SensorControls.test.tsx
+++ b/ui/dashboard/src/components/__tests__/SensorControls.test.tsx
@@ -6,7 +6,7 @@ import { FakeDataProvider } from '../../utils/mock'
 describe('SensorControls', () => {
   it('renders controls', () => {
     const { getByText } = render(
-      <FakeDataProvider>
+      <FakeDataProvider auto={false}>
         <SensorControls />
       </FakeDataProvider>,
     )

--- a/ui/dashboard/src/components/__tests__/SensorTable.test.tsx
+++ b/ui/dashboard/src/components/__tests__/SensorTable.test.tsx
@@ -6,7 +6,7 @@ import { FakeDataProvider } from '../../utils/mock'
 describe('SensorTable', () => {
   it('renders table', () => {
     const { getByText } = render(
-      <FakeDataProvider>
+      <FakeDataProvider auto={false}>
         <SensorTable />
       </FakeDataProvider>,
     )


### PR DESCRIPTION
## Summary
- add sensor management actions in the dashboard store
- disable automatic sensor generation
- extend sensor controls with create and delete options
- update tests for the new provider behaviour

## Testing
- `npx vitest run`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687ac9a57958832d93343e9102aa31d6