### PR TITLE
Fix dashboard backend connection

### DIFF
--- a/ui/dashboard/README.md
+++ b/ui/dashboard/README.md
@@ -10,7 +10,9 @@ npm run dev
 The app will be available at http://localhost:5173.
 
 Set `VITE_API_BASE` to the backend URL (e.g. `http://localhost:8000`) to enable
-API calls from the dashboard.
+API calls from the dashboard. When `VITE_WS_ENDPOINT` is defined, the dashboard
+will connect to that WebSocket endpoint for live data; otherwise it falls back
+to local fake data.
 
 ### Static assets
 

--- a/ui/dashboard/src/App.tsx
+++ b/ui/dashboard/src/App.tsx
@@ -2,25 +2,29 @@ import MapView from './components/MapView'
 import SensorTable from './components/SensorTable'
 import SensorControls from './components/SensorControls'
 import EnergyGauge from './components/EnergyGauge'
+import { WebSocketProvider } from './utils/ws'
 import { FakeDataProvider } from './utils/mock'
 
 export default function App() {
-  return (
-    <FakeDataProvider auto={false}>
-      <div className="container mx-auto p-4 grid gap-4 grid-cols-1 md:grid-cols-2">
-        <div className="h-96 md:row-span-2">
-          <MapView />
-        </div>
-        <div className="bg-white p-4 rounded shadow">
-          <EnergyGauge />
-        </div>
-        <div className="bg-white p-4 rounded shadow">
-          <SensorTable />
-        </div>
-        <div className="bg-white p-4 rounded shadow">
-          <SensorControls />
-        </div>
+  const content = (
+    <div className="container mx-auto p-4 grid gap-4 grid-cols-1 md:grid-cols-2">
+      <div className="h-96 md:row-span-2">
+        <MapView />
       </div>
-    </FakeDataProvider>
+      <div className="bg-white p-4 rounded shadow">
+        <EnergyGauge />
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <SensorTable />
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <SensorControls />
+      </div>
+    </div>
   )
+
+  if (import.meta.env.VITE_WS_ENDPOINT !== undefined) {
+    return <WebSocketProvider>{content}</WebSocketProvider>
+  }
+  return <FakeDataProvider auto={false}>{content}</FakeDataProvider>
 }


### PR DESCRIPTION
## Summary
- enable WebSocketProvider for live data in the dashboard
- document `VITE_WS_ENDPOINT` usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ae8b14ec4832db9e38b823e239097