### PR TITLE
Add auth token header for sensor creation

### DIFF
--- a/ui/dashboard/src/utils/api.ts
+++ b/ui/dashboard/src/utils/api.ts
@@ -1,10 +1,15 @@
 export async function patchEntity(type: string, id: string, patch: object): Promise<void> {
   const base = import.meta.env.VITE_API_BASE || ''
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  }
+  const token = import.meta.env.VITE_API_TOKEN
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
   const resp = await fetch(`${base}/api/entities/${type}/${id}`, {
     method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers,
     body: JSON.stringify(patch),
   })
   if (!resp.ok) {


### PR DESCRIPTION
## Summary
- allow passing a bearer token via `VITE_API_TOKEN` when updating entities from the dashboard

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687af2e37230832db0901a83ec0041a0