### PR TITLE
Add login and token storage

### DIFF
--- a/ui/dashboard/src/App.tsx
+++ b/ui/dashboard/src/App.tsx
@@ -2,10 +2,20 @@ import MapView from './components/MapView'
 import SensorTable from './components/SensorTable'
 import SensorControls from './components/SensorControls'
 import EnergyGauge from './components/EnergyGauge'
+import LoginForm from './components/LoginForm'
 import { WebSocketProvider } from './utils/ws'
 import { FakeDataProvider } from './utils/mock'
+import { useState } from 'react'
 
 export default function App() {
+  const [token, setToken] = useState(() =>
+    import.meta.env.VITE_API_TOKEN || localStorage.getItem('token') || '',
+  )
+
+  if (!token) {
+    return <LoginForm onSuccess={() => setToken(localStorage.getItem('token') || '')} />
+  }
+
   const content = (
     <div className="container mx-auto p-4 grid gap-4 grid-cols-1 md:grid-cols-2">
       <div className="h-96 md:row-span-2">

--- a/ui/dashboard/src/components/LoginForm.tsx
+++ b/ui/dashboard/src/components/LoginForm.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { login } from '../utils/api'
+
+export default function LoginForm({ onSuccess }: { onSuccess: () => void }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const token = await login(username, password)
+      localStorage.setItem('token', token)
+      setError('')
+      onSuccess()
+    } catch {
+      setError('Error de autenticación')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto space-y-2">
+      <div>
+        <input
+          className="border w-full p-2"
+          placeholder="Usuario"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          className="border w-full p-2"
+          type="password"
+          placeholder="Contraseña"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+      </div>
+      {error && <p className="text-red-600">{error}</p>}
+      <button className="px-2 py-1 bg-blue-500 text-white rounded" type="submit">
+        Entrar
+      </button>
+    </form>
+  )
+}

--- a/ui/dashboard/src/components/__tests__/LoginForm.test.tsx
+++ b/ui/dashboard/src/components/__tests__/LoginForm.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import LoginForm from '../LoginForm'
+
+describe('LoginForm', () => {
+  it('renders form', () => {
+    const { getByText } = render(<LoginForm onSuccess={() => {}} />)
+    expect(getByText('Entrar')).toBeTruthy()
+  })
+})

--- a/ui/dashboard/src/utils/api.ts
+++ b/ui/dashboard/src/utils/api.ts
@@ -1,9 +1,23 @@
+export async function login(username: string, password: string): Promise<string> {
+  const base = import.meta.env.VITE_API_BASE || ''
+  const resp = await fetch(`${base}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  })
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`)
+  }
+  const data = await resp.json()
+  return data.access_token
+}
+
 export async function patchEntity(type: string, id: string, patch: object): Promise<void> {
   const base = import.meta.env.VITE_API_BASE || ''
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
   }
-  const token = import.meta.env.VITE_API_TOKEN
+  const token = import.meta.env.VITE_API_TOKEN || localStorage.getItem('token')
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
   }


### PR DESCRIPTION
## Summary
- add login route in context adapter
- store JWT in browser for PATCH calls
- add login form to the dashboard
- test login component

## Testing
- `pytest -q`
- `npx vitest run --coverage false`

------
https://chatgpt.com/codex/tasks/task_b_687af5bfe550832dbfe10b6ee755b8c4